### PR TITLE
ci: fix missing gb7714-2015 dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ jobs:
         if: steps.cache-texlive.outputs.installed != 'true'
         run: |
           tlmgr update --self
-          tlmgr install latex-bin platex uplatex tex xetex
-          tlmgr install latexmk texliveonfly
+          tlmgr install $(cat .github/workflows/texlive-packages)
       - name: Run texliveonfly
         run: texliveonfly -c latexmk example.tex

--- a/.github/workflows/texlive-packages
+++ b/.github/workflows/texlive-packages
@@ -1,0 +1,3 @@
+latex-bin platex uplatex tex xetex
+latexmk texliveonfly
+biber biblatex-gb7714-2015


### PR DESCRIPTION
The biblatex package cannot be installed by texliveonfly.
