### PR TITLE
fix: fix missing graphicx package in cls file

### DIFF
--- a/example.tex
+++ b/example.tex
@@ -4,7 +4,6 @@
 \usepackage{lipsum}
 \usepackage{booktabs}
 \usepackage{hyperref}
-\usepackage{graphicx}
 
 \addbibresource{sample.bib}
 

--- a/swufethesis.cls
+++ b/swufethesis.cls
@@ -144,6 +144,7 @@
 \pagestyle{plain}
 
 % 封面
+\RequirePackage{graphicx}
 \renewcommand{\maketitle}{%
   \thispagestyle{empty} % 取消页码
   \noindent


### PR DESCRIPTION
Package `graphicx` is needed for inserting logo.
