### PR TITLE
refactor: 修复\swufe@define@key未设置alias的错误

### DIFF
--- a/swufethesis.cls
+++ b/swufethesis.cls
@@ -32,6 +32,7 @@
 }
 % 为每一个key设置handler
 \kv@set@family@handler{swufe@key}{%
+  \@namedef{swufe@#1@alias}{#1} % alias默认为key
   \kv@define@key{swufe@value}{alias}{%
     % 用\swufe@<key>@alias存储别名的值
     \@namedef{swufe@#1@alias}{##1}


### PR DESCRIPTION
宏\swufe@<key>@alias由于alias选项未设定而未设定。
补充定义为<key>。
