### PR TITLE
refactor: 关键词作为摘要环境的参数输入

### DIFF
--- a/example.tex
+++ b/example.tex
@@ -14,18 +14,16 @@
   discipline = 这也是我财一个很长很长很长很长很长的专业名称（长到要加备注说明）,
   student-id = 4XXXXXXX,
   supervisor = XX老师,
-  keywords = {毕业论文, 毕业设计, 西南财经大学},
-  keywords* = {Dissertation, Graduation project, Swufe},
 }
 
 \begin{document}
 \maketitle % 封面
 \statement % 版权申明
-\begin{abstract}
+\begin{abstract}{毕业论文, 毕业设计, 西南财经大学}
   \zhlipsum[1]
 \end{abstract}
 
-\begin{abstract*}
+\begin{abstract*}{Dissertation, Graduation project, Swufe}
   \lipsum[1]
 \end{abstract*}
 

--- a/swufethesis.cls
+++ b/swufethesis.cls
@@ -80,10 +80,6 @@
       name = student@id
     },
   supervisor,
-  keywords,
-  keywords* = {
-      name = keywords@en
-    },
 }
 
 % 将逗号分隔列表转为特定分隔符间隔的字串
@@ -147,21 +143,23 @@
 % 关键词和摘要
 \newcommand{\@keywords}[1]{\noindent\textbf{关键词：\swufe@join@clist{#1}{；}}}
 \newcommand{\@@keywords}[1]{\noindent\textbf{Keywords: \swufe@join@clist{#1}{; }}}
-\renewenvironment{abstract}{%
+\renewenvironment{abstract}[1]{%
   \newpage
   \setcounter{page}{1}
   \zihao{-4}
   {\centering\bfseries\zihao{2}摘要\par\vspace{1ex}} % 二号华文中宋
+  \newcommand{\swufe@keywords}{#1}
 }{%
 
   \@keywords{\swufe@keywords}
 }
 
-\newenvironment{abstract*}{%
+\newenvironment{abstract*}[1]{%
   \newpage
   \setcounter{page}{1}
   \zihao{-4}
   {\centering\bfseries\zihao{2}Abstract\par\vspace{1ex}} % 二号Time New Roman
+  \newcommand{\swufe@keywords@en}{#1}
 }{%
 
   \@@keywords{\swufe@keywords@en}


### PR DESCRIPTION
不再提供`keywords`、`keywords*`选项，而是直接作为
`abstract`与`abstract*`环境的参数（必选）。
