### PR TITLE
fix: 保证封面等页面都是右开

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-18.04
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     env:
-      cache-version: v20200107.4
+      cache-version: v20210203.1
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4

--- a/example.tex
+++ b/example.tex
@@ -20,8 +20,9 @@
 \begin{document}
 \maketitle % 封面
 \statement % 版权申明
+
 \begin{abstract}{毕业论文, 毕业设计, 西南财经大学}
-  \zhlipsum[1]
+  \zhlipsum[1-4]
 \end{abstract}
 
 \begin{abstract*}{Dissertation, Graduation project, Swufe}
@@ -30,7 +31,7 @@
 
 \tableofcontents
 
-\setcounter{page}{1}
+\mainmatter % \mainmatter会重置页码样式为阿拉伯数字，并使\chapter被编号
 \chapter{背景介绍}
 \zhlipsum
 \chapter{主体内容}
@@ -68,7 +69,6 @@
 \printbibliography
 \appendix
 \chapter{XX代码}
-\newpage
 \chapter{致谢}
 
 \end{document}

--- a/swufethesis.cls
+++ b/swufethesis.cls
@@ -182,7 +182,7 @@
 \renewcommand{\cftchapfont}{\bfseries} % 字号字体与正文相同故不再设置
 % 目录单独成页
 \let\swufe@tableofcontents\tableofcontents
-\def\tableofcontents{\newpage\setcounter{page}{1}\swufe@tableofcontents\clearpage}
+\def\tableofcontents{\cleardoublepage\swufe@tableofcontents\pagenumbering{arabic}}
 
 \RequirePackage{xparse}
 % \swufe@chapter*[tocline]{title}
@@ -217,12 +217,14 @@
 \let\swufe@oldtable\table
 \def\table[#1]{\swufe@oldtable[#1]\fontsize{10.5bp}{10.5bp}}
 
+\RequirePackage{emptypage} % 使cleardoublepage添加的页面不含页码
+
 % 关键词和摘要
 \newcommand{\@keywords}[1]{\noindent\textbf{关键词：\swufe@join@clist{#1}{；}}}
 \newcommand{\@@keywords}[1]{\noindent\textbf{Keywords: \swufe@join@clist{#1}{; }}}
 \newenvironment{abstract}[1]{%
-  \newpage
-  \setcounter{page}{1}
+  \cleardoublepage
+  \pagenumbering{arabic}
   \swufe@chapter*{摘要}
   \newcommand{\swufe@keywords}{#1}
 }{%
@@ -231,8 +233,8 @@
 }
 
 \newenvironment{abstract*}[1]{%
-  \newpage
-  \setcounter{page}{1}
+  \cleardoublepage
+  \pagenumbering{arabic}
   \swufe@chapter*{Abstract}
   \newcommand{\swufe@keywords@en}{#1}
 }{%
@@ -252,6 +254,7 @@
 % 封面
 \RequirePackage{graphicx}
 \renewcommand{\maketitle}{%
+  \cleardoublepage
   \thispagestyle{empty} % 取消页码
   \noindent
   \includegraphics[scale=0.75]{logo-Swufe.png} % 貌似png图片不包含分辨率信息，需要手动指定 https://tex.stackexchange.com/questions/1625/how-to-make-images-appear-at-their-actual-size
@@ -295,7 +298,7 @@
 
 % 版权申明
 \newcommand{\statement}{
-  \newpage
+  \cleardoublepage
   \thispagestyle{empty} % 取消页码
   \begin{center}
     % 华文中宋 小二加粗


### PR DESCRIPTION
利用`\cleardoublepage`保证封面、学术声明、中英文摘要、目录
都是右开，对打印比较友好。
