### PR TITLE
ci: 修复windows测试的skip ci条件 [skip ci]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,4 @@ updates:
     schedule:
       interval: daily
     commit-message:
-      prefix: 'chore(ci):'
+      prefix: 'ci(deps):'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
   windows-texlive:
     name: Windows TeX Live
     runs-on: windows-2019
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     env:
       cache-version: v20210205.1
     steps:


### PR DESCRIPTION
同时调整dependabot的pr前缀为`ci(deps):`。
