### PR TITLE
refactor: 增加英文字体选项

### DIFF
--- a/example.tex
+++ b/example.tex
@@ -69,6 +69,9 @@
 \printbibliography
 \appendix
 \chapter{XX代码}
+\begin{verbatim}
+Some mono font
+\end{verbatim}
 \begin{acknowledgments}
   谢辞应以简短的文字对课题研究与论文撰写过程中曾直接给予帮助的人员
   （例如指导教师、答疑教师及其他人员）表示对自己的谢意，这不仅是一种礼

--- a/swufethesis.cls
+++ b/swufethesis.cls
@@ -535,3 +535,61 @@
 }
 
 \swufesetup{ cjk-font = auto }
+
+% 英文字体
+\swufe@define@key{%
+  font = {
+      choices = {
+          auto,
+          times,
+          termes,
+        }
+    }
+}
+\newcommand{\swufe@set@font@times}{%
+  \setmainfont{Times New Roman}%
+  \setsansfont{Arial}%
+  \ifswufe@system@mac%
+    \setmonofont{Menlo}%
+  \else%
+    \setmonofont{Courier New}%
+  \fi
+}
+\newcommand{\swufe@set@font@termes}{%
+  \setmainfont{texgyretermes}[
+    Extension = .otf,
+    UprightFont = *-regular,
+    BoldFont = *-bold,
+    ItalicFont = *-italic,
+    BoldItalicFont = *-bolditalic,
+  ]%
+  \setsansfont{texgyreheros}[
+    Extension = .otf,
+    UprightFont = *-regular,
+    BoldFont = *-bold,
+    ItalicFont = *-italic,
+    BoldItalicFont = *-bolditalic,
+  ]%
+  \setsansfont{texgyrecursor}[
+    Extension = .otf,
+    UprightFont = *-regular,
+    BoldFont = *-bold,
+    ItalicFont = *-italic,
+    BoldItalicFont = *-bolditalic,
+  ]%
+}
+
+\swufe@option@hook{font}{%
+  \@nameuse{swufe@set@font@\@nameuse{swufe@font}}%
+}
+\newcommand{\swufe@set@font@auto}{%
+  \ifswufe@system@unix%
+    \IfFontExistsTF{texgyretermes-regular.otf}{%
+      \swufesetup{ font = termes }%
+    }{}%
+  \else%
+    % Windoes与mac采用times方案
+    \swufesetup{ font = times }%
+  \fi
+}
+\swufesetup{ font = auto }


### PR DESCRIPTION
设置英文字体选项`font`，有方案`auto`、`times`与`termes`。
方案`auto`在mac与windows下选取`times`方案，即Times New Roman
与Arial，等宽字体分别为Menlo与Courier New。
对于linux系统，如果安装了tex-gyre字体包，则选取
TeX Gyre Termes, Heros, Cursor。
