### PR TITLE
refactor: 使用three matters来增强结构性

### DIFF
--- a/example.tex
+++ b/example.tex
@@ -1,4 +1,4 @@
-\documentclass[openany]{swufethesis}
+\documentclass{swufethesis}
 
 \usepackage{booktabs}
 \usepackage{hyperref}
@@ -20,6 +20,7 @@
 \maketitle % 封面
 \statement % 版权申明
 
+\frontmatter % \frontmatter重置页码，取消后续章节的编号
 \begin{abstract}{毕业论文, 毕业设计, 西南财经大学}
   摘要内容应概括地反映出本论文的主要内容，主要说明本论文的研究目的、
   内容、方法、成果和结论。语言力求精练、准确，摘要字数300字左右。
@@ -39,7 +40,7 @@
 
 \tableofcontents
 
-\mainmatter % \mainmatter会重置页码样式为阿拉伯数字，并使\chapter被编号
+\mainmatter % \mainmatter重置页码，并开始为后续章节编号
 \chapter{毕业论文的撰写规范}
 本科生毕业论文写作是反映学生毕业论文工作成效的重要途经，是考核学生
 掌握和运用所学基础理论、基本知识、基本技能从事科学研究和解决实际问题能
@@ -115,6 +116,7 @@
 \begin{verbatim}
 Some mono font
 \end{verbatim}
+\backmatter % \backmatter标记附录结束，取消后续章节的编号
 \begin{acknowledgments}
   谢辞应以简短的文字对课题研究与论文撰写过程中曾直接给予帮助的人员
   （例如指导教师、答疑教师及其他人员）表示对自己的谢意，这不仅是一种礼

--- a/swufethesis.cls
+++ b/swufethesis.cls
@@ -226,6 +226,36 @@
     }
 }
 
+% Three matters
+\renewcommand{\frontmatter}{%
+  \cleardoublepage
+  \@mainmatterfalse
+  \pagenumbering{arabic}%
+}
+\renewcommand{\mainmatter}{%
+  \cleardoublepage
+  \@mainmattertrue
+  \pagenumbering{arabic}%
+}
+\renewcommand{\backmatter}{%
+  \ifswufe@output@check\end{document}\fi % 检测版直接结束
+  \if@openright
+    \cleardoublepage
+  \else
+    \clearpage
+  \fi
+  \@mainmatterfalse%
+}
+
+\swufe@define@key{
+  output = {
+      choices = {
+          print,
+          check, % 检测版
+        }
+    }
+}
+
 % 目录
 \RequirePackage[titles]{tocloft} % 启用titles选项使其采用ctex对章节标题的设定来设置最上层标题
 \renewcommand{\cftchapfont}{\bfseries} % 字号字体与正文相同故不再设置
@@ -322,18 +352,20 @@
 % 封面
 \RequirePackage{graphicx}
 \renewcommand{\maketitle}{%
-  \cleardoublepage
-  % 虽然规范上要求上下左右页边距为3cm，但实际给出的封面与申明页模板采用的Word默认页边距
-  % 为达到一致的视觉效果，对封面页和申明页使用特别的页边距，并在其他页面重置
-  \newgeometry{
-    vmargin=2.54cm,
-    hmargin=3.18cm,
-  }
-  \thispagestyle{empty} % 取消页码
-  \ifswufe@degree@bachelor%
-    \swufe@make@bachelor@cover%
-  \else%
-    \swufe@make@postgraduate@titlepage%
+  \ifswufe@output@check\else%
+    \cleardoublepage
+    % 虽然规范上要求上下左右页边距为3cm，但实际给出的封面与申明页模板采用的Word默认页边距
+    % 为达到一致的视觉效果，对封面页和申明页使用特别的页边距，并在其他页面重置
+    \newgeometry{
+      vmargin=2.54cm,
+      hmargin=3.18cm,
+    }
+    \thispagestyle{empty} % 取消页码
+    \ifswufe@degree@bachelor%
+      \swufe@make@bachelor@cover%
+    \else%
+      \swufe@make@postgraduate@titlepage%
+    \fi%
   \fi%
 }
 
@@ -443,14 +475,16 @@
 
 % 版权申明
 \newcommand{\statement}{
-  \cleardoublepage
-  \thispagestyle{empty} % 取消页码
-  \ifswufe@degree@bachelor%
-    \swufe@make@bachelor@statement%
-  \else%
-    \swufe@make@postgraduate@statement%
-  \fi%
-  \restoregeometry
+  \ifswufe@output@check\else%
+    \cleardoublepage
+    \thispagestyle{empty} % 取消页码
+    \ifswufe@degree@bachelor%
+      \swufe@make@bachelor@statement%
+    \else%
+      \swufe@make@postgraduate@statement%
+    \fi%
+    \restoregeometry
+  \fi
 }
 
 \newcommand{\swufe@make@bachelor@statement}{
@@ -571,9 +605,13 @@
 \RequirePackage{pdfpages}
 \RequirePackage{filehook} % file hooks已可以由LaTeX core (2020/10/01)原生支持，这个宏包可提供兼容性
 \AtEndDocument{%
-  \cleardoublepage%
-  \null\thispagestyle{empty}\newpage% 封底前面插入空白页保证封底在下
-  \includepdf{backcover.pdf}%
+  \ifswufe@output@check\else%
+    \ifswufe@degree@bachelor%
+      \cleardoublepage%
+      \null\thispagestyle{empty}\newpage% 封底前面插入空白页保证封底在下
+      \includepdf{backcover.pdf}%
+    \fi
+  \fi
 }
 
 \swufe@define@key{


### PR DESCRIPTION
`\frontmatter`标记摘要、目录章节的开始，`\mainmatter`标记正文开始，`\backmatter`标记附录结束。
同时增加output选项，当指定为`check`时，将只输出`\frontmatter`与`\backmatter`之间的内容。
