### PR TITLE
fix: 修复geometry的加载时间

### DIFF
--- a/swufethesis.cls
+++ b/swufethesis.cls
@@ -151,7 +151,7 @@
 }
 
 \RequirePackage{geometry}
-\AtBeginDocument{%
+\swufe@option@hook{degree}{%
   \ifswufe@degree@bachelor%
     \geometry{
       a4paper,


### PR DESCRIPTION
`\geometry`不应用于`\AtBeginDocument`，此时设置用该命令设置布局是无效的。
改在`degree`设置之后。
