### PR TITLE
ci: 添加.ci-dock目录作为CI沙盒

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
     name: Lint code
     runs-on: ubuntu-18.04
     env:
-      cache-version: v20210203.1
+      cache-version: v20210303.1
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4
@@ -17,7 +17,7 @@ jobs:
         uses: actions/cache@v2.1.4
         with:
           path: |
-            latexindent
+            .ci-dock
             /opt/hostedtoolcache/perl
           key: lint-${{ runner.os }}-${{ env.cache-version }}
       - name: Install latexindent

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cache-version: [v20210301.3]
+        cache-version: [v20210303.1]
         os:
           - ubuntu-18.04
           - macos-10.15
@@ -31,22 +31,15 @@ jobs:
         id: cache
         uses: actions/cache@v2.1.4
         with:
-          path: tl
+          path: .ci-dock
           key: tl-${{ runner.os }}-${{ hashFiles('ci/texlive-packages') }}-${{ matrix.cache-version }}
       - name: Set up PATH
         shell: bash
-        run: |
-          if [ "$RUNNER_OS" == "Linux" ]; then
-            echo "${{ github.workspace }}/tl/bin/x86_64-linux" >> $GITHUB_PATH
-          elif [ "$RUNNER_OS" == "macOS" ]; then
-            echo "${{ github.workspace }}/tl/bin/x86_64-darwin" >> $GITHUB_PATH
-          else
-            echo "${{ github.workspace }}\tl\bin\win32" >> $GITHUB_PATH
-          fi
+        run: source ci/texlive-path.sh >> $GITHUB_PATH
       - name: Install TeX Live
         if: steps.cache.outputs.cache-hit != 'true'
         shell: bash
-        run: source ci/texlive-install.sh "${{ github.workspace }}/tl"
+        run: source ci/texlive-install.sh
       - name: l3build
         shell: bash
         run: l3build check -q

--- a/ci/latexindent-deps-install.sh
+++ b/ci/latexindent-deps-install.sh
@@ -2,4 +2,4 @@
 
 set -ev
 
-echo Y | latexindent/latexindent-module-installer.pl
+echo Y | .ci-dock/indent/latexindent-module-installer.pl

--- a/ci/latexindent-install.sh
+++ b/ci/latexindent-install.sh
@@ -4,3 +4,4 @@ set -ev
 
 curl -sOL http://mirrors.ctan.org/support/latexindent.zip
 unzip -q latexindent.zip
+mv latexindent .ci-dock/indent

--- a/ci/latexindent.sh
+++ b/ci/latexindent.sh
@@ -3,9 +3,9 @@
 set -ev
 
 for f in $(find \
-  -path ./latexindent -prune -false \
+  -path ./.ci-dock -prune -false \
   -or -name '*.tex' \
   -or -name '*.cls' \
   -or -name '*.bib'); do
-  latexindent/latexindent.pl -l "$f" | diff "$f" -
+  .ci-dock/indent/latexindent.pl -l "$f" | diff "$f" -
 done

--- a/ci/pwd.sh
+++ b/ci/pwd.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+
+set -e
+
+# 这个脚本输出$PWD，但会在Git Bash (Windows)下会将路径转为Windows的格式
+if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
+  # 下面sed使用`|`作为分割符，并启用\(group capture\)
+  # 先提取$PWD的盘符和其余部分
+  disk=$(echo $PWD | sed 's|^/\([cd]\)/.*|\1|' | tr 'a-z' 'A-Z')
+  after_disk=$(echo $PWD | sed 's|/[cd]/\(.*\)|\1|')
+  # 再拼接并替换路径分隔符
+  echo "$disk:/$after_disk" | sed 's|/|\\|g'
+else
+  echo $PWD
+fi

--- a/ci/texlive-install.sh
+++ b/ci/texlive-install.sh
@@ -12,10 +12,12 @@ fi
 
 # 替换profile中的模板字串
 # 该脚本的第一个参数作为texlive的安装路径
-# 由于$1中可能含有`/`、`\`、`:`，故使用`#`作为sed的分隔符，
-# 同时提前把$1中的`\`替换为`/` ${1//<pattern>/<substitution>}替换所有
+# 由于路径中可能含有`/`、`\`、`:`，故使用`#`作为sed的分隔符，
+# 同时提前把$tl_path中的`\`替换为`/`（即使是Windows，profile里面的路径分割符也是`/`）
+# ${var//<pattern>/<substitution>}替换所有
 # 这里也不使用sed的-i参数进行就地替换，因为MacOS上sed可能不是GNU sed，形式有点不一样
-sed "s#\$TL_DIR#${1//\\//}#g" ci/tl.profile > ci/texlive.profile
+tl_path="$(source ci/pwd.sh)/.ci-dock/tl"
+sed "s#\$TL_DIR#${tl_path//\\//}#g" ci/tl.profile > ci/texlive.profile
 
 curl -sLO http://mirror.ctan.org/systems/texlive/tlnet/install-tl.zip
 unzip -q install-tl.zip

--- a/ci/texlive-path.sh
+++ b/ci/texlive-path.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+
+set -ev
+
+if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
+  # 下面sed使用`|`作为分割符
+  echo "$(source ci/pwd.sh)/.ci-dock/tl/bin/win32" | sed 's|/|\\|g'
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  echo $PWD/.ci-dock/tl/bin/x86_64-darwin
+else
+  echo $PWD/.ci-dock/tl/bin/x86_64-linux
+fi


### PR DESCRIPTION
CI上临时下载的文件全部放入.ci-dock目录，便于统一缓存。
