### PR TITLE
ci: 对push事件也进行lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,7 @@
 name: Lint
 on:
+  push:
+    branches: main
   pull_request:
     branches: main
 


### PR DESCRIPTION
一是可以提醒被推到主分支上的代码格式错误，
二是Github cache是可以跨分支使用的（包含当前分支、base
和默认分支），这样在主分支上运行该workflow，可以让
每个新开的pr也有cache使用。